### PR TITLE
Fixed 8n-1 issue, added tests

### DIFF
--- a/smspdu/codecs.py
+++ b/smspdu/codecs.py
@@ -61,6 +61,9 @@ class GSM:
                 res += cls.ALPHABET_EXT.get(char_index, ' ')
             else:
                 res += cls.ALPHABET[char_index]
+        if len(res) % 8 == 0:
+            if res.endswith("\r"):
+                res = res[:-1]
         return res
 
     @classmethod
@@ -78,6 +81,8 @@ class GSM:
         >>> GSM.encode("2 € par mois")
         '32D0A60C8287E5A0F63B3D07'
         """
+        if (len(data) + 1) % 8 == 0:
+            data = data + "\r"
         chars = list()
         for char in data:
             try:

--- a/smspdu/codecs.py
+++ b/smspdu/codecs.py
@@ -42,7 +42,7 @@ class GSM:
         r"""
         Returns decoded message from PDU string.
 
-        If with_padding argument is true and the total number of characters to be sent equals to (8n-1) where n=1,2,3,
+        If strip_padding argument is true and the total number of characters to be sent equals to (8n-1) where n=1,2,3,
         etc, then there are 7 spare bits at the end of the message and the last padding character is <CR>, the decode
         function removes this last <CR>.
 
@@ -57,11 +57,11 @@ class GSM:
         >>> GSM.decode('32D0A60C8287E5A0F63B3D07')
         '2 € par mois'
 
-        Decodes without padding
+        Decodes without strip padding
         >>> GSM.decode('AA58ACA6AA8D1A')
         '*115*5#\r'
 
-        Decodes with padding, removes the last <CR>
+        Decodes with strip padding, removes the last <CR>
         >>> GSM.decode('AA58ACA6AA8D1A', True)
         '*115*5#'
         """

--- a/smspdu/codecs.py
+++ b/smspdu/codecs.py
@@ -11,6 +11,7 @@ from bitstring import BitStream
 
 __all__ = ['GSM', 'UCS2']
 
+
 class GSM:
     """
     GSM 7-bit SMS codec
@@ -38,7 +39,7 @@ class GSM:
 
     @classmethod
     def decode(cls, data: str, with_padding: bool = False) -> str:
-        """
+        r"""
         Returns decoded message from PDU string.
 
         Some examples:
@@ -49,11 +50,11 @@ class GSM:
         >>> GSM.decode('32D0A60C8287E5A0F63B3D07')
         '2 € par mois'
 
-        Decode without end padding
+        Decodes without padding
         >>> GSM.decode('AA58ACA6AA8D1A')
-        '*115*5#\\r'
+        '*115*5#\r'
 
-        Decode with padding, remove the last <cr>
+        Decodes with padding, remove the last <CR>
         >>> GSM.decode('AA58ACA6AA8D1A', True)
         '*115*5#'
         """
@@ -91,11 +92,11 @@ class GSM:
         >>> GSM.encode("2 € par mois")
         '32D0A60C8287E5A0F63B3D07'
 
-        Encode without end padding
+        Encodes without padding
         >>> GSM.encode('*115*5#')
         'AA58ACA6AA8D00'
 
-        Encode with padding, add an <cr> at the end
+        Encodes with padding, add an <CR> at the end
         >>> GSM.encode('*115*5#', True)
         'AA58ACA6AA8D1A'
         """

--- a/smspdu/codecs.py
+++ b/smspdu/codecs.py
@@ -137,7 +137,7 @@ class GSM:
             chars.append(char_index)
 
         if with_padding:
-            if len(chars) % 8 == 0 and data[-1] == '\r':
+            if len(chars) % 8 == 0 and data[-1:] == '\r':
                 chars.append(cls.ALPHABET.index('\r'))
             if len(chars) % 8 == 7:
                 chars.append(cls.ALPHABET.index('\r'))

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -33,3 +33,19 @@ class GSMEncodingTestCase(unittest.TestCase):
         )
         self.assertEqual(GSM.encode(DATA_DECODED), DATA_ENCODED)
         self.assertEqual(GSM.decode(DATA_ENCODED), DATA_DECODED)
+
+    def test_8n_1_encode(self):
+        N1_ENCODED = '31D98C56B3DD1A'
+        N1_DECODED = '1234567'
+        self.assertEqual(GSM.encode(N1_DECODED), N1_ENCODED)
+
+        N2_ENCODED = 'B0986C46ABD96EB85C503824161B'
+        N2_DECODED = '0123456789ABCDE'
+        self.assertEqual(GSM.encode(N2_DECODED), N2_ENCODED)
+
+    def test_8n_1_decode(self):
+        N1 = '1234567'
+        self.assertEqual(GSM.decode(GSM.encode(N1)), N1)
+
+        N2 = '0123456789ABCDE'
+        self.assertEqual(GSM.decode(GSM.encode(N2)), N2)

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -36,39 +36,39 @@ class GSMEncodingTestCase(unittest.TestCase):
         self.assertEqual(GSM.decode(DATA_ENCODED), DATA_DECODED)
 
     def test_ext_alphabet(self):
-        N1_ENCODED = '31D98C56B36DCA0D'
-        N1_DECODED = '123456€\r'
-        self.assertEqual(GSM.encode(N1_DECODED, True), N1_ENCODED)
+        self.assertEqual(GSM.encode('123456€\r', with_padding=True), '31D98C56B36DCA0D')
 
-        N2_ENCODED = '31D98C56B3DD700D'
-        N2_DECODED = '12345678\r'
-        self.assertEqual(GSM.encode(N2_DECODED, True), N2_ENCODED)
+        self.assertEqual(GSM.encode('12345678\r',  with_padding=True), '31D98C56B3DD700D')
 
     def test_double_cr(self):
-        N1_ENCODED = 'B158ACB629371A'
-        N1_DECODED = '1115€\r'
-        self.assertEqual(GSM.encode(N1_DECODED, True), N1_ENCODED)
-        self.assertEqual("{0:b}".format(int(N1_ENCODED, 16)),
-                         '10110001010110001010110010110110001010010011011100011010')
+        self.assertEqual(GSM.decode(GSM.encode('1234567\r', with_padding=True), strip_padding=True), '1234567\r\r')
+        self.assertEqual(GSM.decode(GSM.encode('1234567\r', with_padding=True), strip_padding=False), '1234567\r\r')
 
-        N2_ENCODED = 'AA58ACA6AA351A'
-        N2_DECODED = '*115*5\r'
-        self.assertEqual(GSM.encode(N2_DECODED, True), N2_ENCODED)
-        self.assertEqual("{0:b}".format(int(N2_ENCODED, 16)),
-                         '10101010010110001010110010100110101010100011010100011010')
+        self.assertEqual(GSM.decode(GSM.encode('1234567\r', with_padding=False), strip_padding=True), '1234567')
+        self.assertEqual(GSM.decode(GSM.encode('1234567\r', with_padding=False), strip_padding=False), '1234567\r')
+
+        self.assertEqual(GSM.decode(GSM.encode('123456\r', with_padding=True), strip_padding=True), '123456\r')
+        self.assertEqual(GSM.decode(GSM.encode('123456\r', with_padding=True), strip_padding=False), '123456\r\r')
+
+        self.assertEqual(GSM.decode(GSM.encode('12345\r', with_padding=True), strip_padding=True), '12345\r')
+        self.assertEqual(GSM.decode(GSM.encode('12345\r', with_padding=True), strip_padding=False), '12345\r')
+
+        self.assertEqual(GSM.decode(GSM.encode('123456\r\r', with_padding=True), strip_padding=True), '123456\r\r\r')
+        self.assertEqual(GSM.decode(GSM.encode('123456\r\r', with_padding=True), strip_padding=False), '123456\r\r\r')
 
     def test_8n_1_encode(self):
-        N1_ENCODED = '31D98C56B3DD1A'
-        N1_DECODED = '1234567'
-        self.assertEqual(GSM.encode(N1_DECODED, True), N1_ENCODED)
+        self.assertEqual(GSM.encode('1234567', True), '31D98C56B3DD1A')
 
-        N2_ENCODED = 'B0986C46ABD96EB85C503824161B'
-        N2_DECODED = '0123456789ABCDE'
-        self.assertEqual(GSM.encode(N2_DECODED, True), N2_ENCODED)
+        self.assertEqual(GSM.encode('0123456789ABCDE', True), 'B0986C46ABD96EB85C503824161B')
+
+        self.assertEqual(GSM.decode(GSM.encode('1234567', with_padding=True), strip_padding=True), '1234567')
+        self.assertEqual(GSM.decode(GSM.encode('12345^', with_padding=True), strip_padding=True), '12345^')
+        self.assertEqual(GSM.decode(GSM.encode('12345^', with_padding=True), strip_padding=False), '12345^\r')
+        self.assertEqual(GSM.decode(GSM.encode('123456^', with_padding=True), strip_padding=True), '123456^')
+        self.assertEqual(GSM.decode(GSM.encode('123456^', with_padding=True), strip_padding=False), '123456^')
 
     def test_8n_1_decode(self):
-        N1 = '1234567'
-        self.assertEqual(GSM.decode(GSM.encode(N1, True), True), N1)
+        self.assertEqual(GSM.decode(GSM.encode('1234567', with_padding=True), strip_padding=True), '1234567')
 
-        N2 = '0123456789ABCDE'
-        self.assertEqual(GSM.decode(GSM.encode(N2, True), True), N2)
+        self.assertEqual(GSM.decode(GSM.encode('0123456789ABCDE', with_padding=True),
+                                    strip_padding=True), '0123456789ABCDE')

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -37,15 +37,15 @@ class GSMEncodingTestCase(unittest.TestCase):
     def test_8n_1_encode(self):
         N1_ENCODED = '31D98C56B3DD1A'
         N1_DECODED = '1234567'
-        self.assertEqual(GSM.encode(N1_DECODED), N1_ENCODED)
+        self.assertEqual(GSM.encode(N1_DECODED, True), N1_ENCODED)
 
         N2_ENCODED = 'B0986C46ABD96EB85C503824161B'
         N2_DECODED = '0123456789ABCDE'
-        self.assertEqual(GSM.encode(N2_DECODED), N2_ENCODED)
+        self.assertEqual(GSM.encode(N2_DECODED, True), N2_ENCODED)
 
     def test_8n_1_decode(self):
         N1 = '1234567'
-        self.assertEqual(GSM.decode(GSM.encode(N1)), N1)
+        self.assertEqual(GSM.decode(GSM.encode(N1, True), True), N1)
 
         N2 = '0123456789ABCDE'
-        self.assertEqual(GSM.decode(GSM.encode(N2)), N2)
+        self.assertEqual(GSM.decode(GSM.encode(N2, True), True), N2)

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -21,6 +21,7 @@ class GSMEncodingTestCase(unittest.TestCase):
 
     def test_empty(self):
         self.assertEqual(GSM.encode(''), GSM.decode(''), '')
+        self.assertEqual(GSM.encode('', with_padding=True), GSM.decode('', strip_padding=True), '')
 
     def test_long(self):
         DATA_DECODED = (
@@ -37,7 +38,6 @@ class GSMEncodingTestCase(unittest.TestCase):
 
     def test_ext_alphabet(self):
         self.assertEqual(GSM.encode('123456€\r', with_padding=True), '31D98C56B36DCA0D')
-
         self.assertEqual(GSM.encode('12345678\r',  with_padding=True), '31D98C56B3DD700D')
 
     def test_double_cr(self):
@@ -66,9 +66,3 @@ class GSMEncodingTestCase(unittest.TestCase):
         self.assertEqual(GSM.decode(GSM.encode('12345^', with_padding=True), strip_padding=False), '12345^\r')
         self.assertEqual(GSM.decode(GSM.encode('123456^', with_padding=True), strip_padding=True), '123456^')
         self.assertEqual(GSM.decode(GSM.encode('123456^', with_padding=True), strip_padding=False), '123456^')
-
-    def test_8n_1_decode(self):
-        self.assertEqual(GSM.decode(GSM.encode('1234567', with_padding=True), strip_padding=True), '1234567')
-
-        self.assertEqual(GSM.decode(GSM.encode('0123456789ABCDE', with_padding=True),
-                                    strip_padding=True), '0123456789ABCDE')

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -5,6 +5,7 @@ import unittest
 
 from smspdu.codecs import GSM
 
+
 class GSMEncodingTestCase(unittest.TestCase):
     def test_hello(self):
         self.assertEqual(GSM.encode('hello'), 'E8329BFD06')
@@ -33,6 +34,28 @@ class GSMEncodingTestCase(unittest.TestCase):
         )
         self.assertEqual(GSM.encode(DATA_DECODED), DATA_ENCODED)
         self.assertEqual(GSM.decode(DATA_ENCODED), DATA_DECODED)
+
+    def test_ext_alphabet(self):
+        N1_ENCODED = '31D98C56B36DCA0D'
+        N1_DECODED = '123456€\r'
+        self.assertEqual(GSM.encode(N1_DECODED, True), N1_ENCODED)
+
+        N2_ENCODED = '31D98C56B3DD700D'
+        N2_DECODED = '12345678\r'
+        self.assertEqual(GSM.encode(N2_DECODED, True), N2_ENCODED)
+
+    def test_double_cr(self):
+        N1_ENCODED = 'B158ACB629371A'
+        N1_DECODED = '1115€\r'
+        self.assertEqual(GSM.encode(N1_DECODED, True), N1_ENCODED)
+        self.assertEqual("{0:b}".format(int(N1_ENCODED, 16)),
+                         '10110001010110001010110010110110001010010011011100011010')
+
+        N2_ENCODED = 'AA58ACA6AA351A'
+        N2_DECODED = '*115*5\r'
+        self.assertEqual(GSM.encode(N2_DECODED, True), N2_ENCODED)
+        self.assertEqual("{0:b}".format(int(N2_ENCODED, 16)),
+                         '10101010010110001010110010100110101010100011010100011010')
 
     def test_8n_1_encode(self):
         N1_ENCODED = '31D98C56B3DD1A'


### PR DESCRIPTION
I'm using your library for my work, where I need to send USSD codes. Some of devices require AT+CUSD command to have the USSD code encoded with 7-bit PDU, so this is where I use your project. It looks like this one:
`AT+CUSD=1,"AA58ACA6B28D1A",15\r`
In simple words, I use `GSM.encode()` to encode my USSD code, i put it into AT command above, then I get response encoded with PDU which I decode obviously with `GSM.decode()`

I had issue with sending command `*115*5#`, because I wasn't getting any response from GSM modems. It was strange, because all the other commands encoded with your library were all right.

After some search I found out that PDU algorithm requires special treatment for strings 8n-1 chars long (n=1,2,3...). In general, they require to be padded with <CR> char before you start encoding. More info you can find in [specification](https://www.etsi.org/deliver/etsi_i_ets/300900_300999/300900/03_60/ets_300900e03p.pdf), _on page 17_. In simple words, command `*115*5#` was encoded wrong because it was (8*1-1=7) chars long.

You can notice issue when you try to decode and encode the same string, like in this examples:
```
>>> from smspdu.codecs import GSM
>>> GSM.decode(GSM.encode('1234567'))
'1234567@'
>>> GSM.decode(GSM.encode('0123456789ABCDE'))
'0123456789ABCDE@'
```
All the tests strings have this thing in common: if you add 1 to their actual length, you'll get number dividable by 8.

You can compare results from your library with [SMSTools3 PDU Converter](http://smstools3.kekekasvi.com/topic.php?id=288). You can put your string to encode into **Text** field, then you will see encoded string in **USSD Entry/Display field**. Then you can convert it back with the appropriate **Convert>** button. When you press it, you'll see decoded string with annotation **(Had padding which is removed)**. Results from function GSM.encode are almost every time equal to these generated at online converter, with except of these specific-length ones. For example:
```
>>> GSM.encode('*115*5#')
'AA58ACA6AA8D00'
             ||
-AA58ACA6B28D1A- <-- this one was encoded at SMSTools3 PDU Converter
```
When I put latter encoded USSD code, my GSM modem process the command correctly. I'd like to say that I didn't create pull request only because of my specific hardware. I suppose that there can be more devices which works with the specification I linked above. For this reason one day somebody could open an issue with the same problem that I had. I hope my solution would help those people.